### PR TITLE
Add support for Fedora

### DIFF
--- a/rsshfs
+++ b/rsshfs
@@ -11,12 +11,16 @@ quote() {
     [[ $# != 0 ]] && printf '%q ' "$@" | sed 's/.$//'
 }
 
+printerr() {
+    printf "$@" >&2
+}
+
 if [[ $# -lt 2 ]]
 then
-    printf "Error: missing parameters\n" >&2
-    printf "Usage:\n" >&2
-    printf "  $0 <localpath> <remotehost>:<remotepath> [-o ro]\n" >&2
-    printf "  $0 -u <remotehost>:<remotepath>\n" >&2
+    printerr "Error: missing parameters\n"
+    printerr "Usage:\n"
+    printerr "  $0 <localpath> <remotehost>:<remotepath> [-o ro]\n"
+    printerr "  $0 -u <remotehost>:<remotepath>\n"
     exit 1;
 fi
 

--- a/rsshfs
+++ b/rsshfs
@@ -15,6 +15,20 @@ printerr() {
     printf "$@" >&2
 }
 
+sftp_server_path() {
+    local searchpaths=(
+        "/usr/lib/openssh/sftp-server"      # Debian
+        "/usr/libexec/openssh/sftp-server"  # Fedora
+    )
+    for path in "${searchpaths[@]}"
+    do
+        [ -x "$path" ] && echo $path && return 0
+    done
+
+    printerr "Error: could not find 'sftp-server'\n"
+    exit 1
+}
+
 if [[ $# -lt 2 ]]
 then
     printerr "Error: missing parameters\n"
@@ -58,7 +72,7 @@ else
     fifo=/tmp/rsshfs-$$
     rm -f "$fifo"
     mkfifo -m600 "$fifo" &&
-    < "$fifo" /usr/lib/openssh/sftp-server "${sftpargs[@]}" |
+    < "$fifo" "$(sftp_server_path)" "${sftpargs[@]}" |
       ssh "$rhost" sshfs -o slave ":$qlpath" "$qrpath" "$qall" > "$fifo"
     rm "$fifo"
 fi


### PR DESCRIPTION
Hi there,

This fixes #2 by adding a "search path" functionality in order to find the sftp-server. This makes rsshfs compatible with Debian *and* Fedora.

It also makes the whole system "future-proof", since one can add additional "search paths".

Let me know what you think.